### PR TITLE
Fix missing ops import

### DIFF
--- a/froog/__init__.py
+++ b/froog/__init__.py
@@ -1,6 +1,7 @@
 import froog.optim
 import froog.tensor
 import froog.utils
+import froog.ops  # ensure tensor operations are registered on import
 
 # Import GPU packages
 import froog.gpu.cl.cl_utils


### PR DESCRIPTION
## Summary
- ensure tensor operations are registered when importing package

## Testing
- `pytest tests/test_optim.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e0f2a234832480d33d6018aa6ee7