### PR TITLE
Fix Linear import in docs

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -45,7 +45,7 @@ We support a few different optimizers, [here](https://github.com/kevbuh/froog/bl
 ```python
 from froog.tensor import Tensor
 import froog.optim as optim
-from froog.nn import Linear
+from froog.ops import Linear
 
 class mnistMLP:
   def __init__(self):

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here's how you set up a simple multilayer perceptron for classification on MNIST
 
 ```python
 from froog.tensor import Tensor
-from froog.nn import Linear
+from froog.ops import Linear
 import froog.optim as optim
 
 class mnistMLP:


### PR DESCRIPTION
## Summary
- fix import path for `Linear` in README and DOCS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6866e2d06c348324852658572f9fcf96