### PR TITLE
Update GPU device test

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,25 +1,29 @@
 import numpy as np
+import pytest
 from froog import get_device
 from froog.tensor import Tensor
 
 def test_device_abstraction():
-    # Get the default device
     device = get_device()
-    assert device is not None, "No default device found"
-    # Test tensor creation and movement to GPU
-    if device.is_available():
-        # Create a tensor on CPU
-        a = Tensor([1.0, 2.0, 3.0])
-        assert np.array_equal(a.data, [1.0, 2.0, 3.0]), "Tensor data mismatch on CPU"
-        # Move to GPU
-        a_gpu = a.to_gpu()
-        assert a_gpu.gpu, "Tensor not moved to GPU"
-        # Move back to CPU
-        a_cpu = a_gpu.to_cpu()
-        assert np.array_equal(a_cpu.data, [1.0, 2.0, 3.0]), "Tensor data mismatch after moving back to CPU"
-        # Test basic operations on GPU
-        b = Tensor([4.0, 5.0, 6.0]).to_gpu()
-        c = a_gpu + b
-        assert np.array_equal(c.to_cpu().data, [5.0, 7.0, 9.0]), "Addition result mismatch on GPU"
-    else:
-        assert False, "No GPU device available for testing"
+    # Skip the test if no GPU is present
+    if device is None or device.name == "CPU":
+        pytest.skip("No GPU device available for testing")
+
+    assert device.is_available(), "GPU device reported as unavailable"
+
+    # Create a tensor on CPU
+    a = Tensor([1.0, 2.0, 3.0])
+    assert np.array_equal(a.data, [1.0, 2.0, 3.0]), "Tensor data mismatch on CPU"
+
+    # Move to GPU
+    a_gpu = a.to_gpu()
+    assert a_gpu.gpu, "Tensor not moved to GPU"
+
+    # Move back to CPU
+    a_cpu = a_gpu.to_cpu()
+    assert np.array_equal(a_cpu.data, [1.0, 2.0, 3.0]), "Tensor data mismatch after moving back to CPU"
+
+    # Test basic operations on GPU
+    b = Tensor([4.0, 5.0, 6.0]).to_gpu()
+    c = a_gpu + b
+    assert np.array_equal(c.to_cpu().data, [5.0, 7.0, 9.0]), "Addition result mismatch on GPU"


### PR DESCRIPTION
## Summary
- skip GPU device test when no GPU is present
- ensure tensor operations on the GPU are still validated when available

## Testing
- `python -m pytest tests/test_device.py -q`
- `python -m pytest -k device -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6866e5f30d3083248c024d7ea14c306c